### PR TITLE
Update api_proxy.php

### DIFF
--- a/api_proxy.php
+++ b/api_proxy.php
@@ -33,7 +33,7 @@ unset($_GET['path']);
 
 $curl = curl_init();
 
-curl_setopt($curl, CURLOPT_URL, 'https://api.wmspanel.com'.$path.'?'.http_build_query($_GET));
+curl_setopt($curl, CURLOPT_URL, 'https://api.wmspanel.com'.$path.'&'.http_build_query($_GET));
 curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $_SERVER['REQUEST_METHOD']);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' || $_SERVER['REQUEST_METHOD'] === 'PUT') {


### PR DESCRIPTION
curl_setopt($curl, CURLOPT_URL, 'https://api.wmspanel.com'.$path.'?'.http_build_query($_GET));

has a ? instead of the &

curl_setopt($curl, CURLOPT_URL, 'https://api.wmspanel.com'.$path.'&'.http_build_query($_GET))

? result in a 403 from CloudFlare. and request is wrong.