### PR TITLE
Updated example for current PHP versions + new example for (un)publish signature validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# don't commit the log file
+log.txt

--- a/stream-un-publish-notify.php
+++ b/stream-un-publish-notify.php
@@ -1,11 +1,15 @@
 <?php
 // WMSPanel publish/un-publish streams events notification sample
 
-$r = $HTTP_RAW_POST_DATA;
+if($_SERVER['REQUEST_METHOD'] !== "POST") {
+    die("notifications are only sent as a POST request.");
+}
+
+$data = file_get_contents("php://input");
 
 $fp = fopen('log.txt', 'a+');
 
-fwrite($fp, $r);
+fwrite($fp, $data);
 
 fwrite($fp, "\r\n\r\n");
 
@@ -13,7 +17,7 @@ fwrite($fp, "\r\n\r\n");
 
 // Use this further processing in case you have PECL installed
 
-$notification = json_decode($r, true); 
+$notification = json_decode($data, true);
 
 // example of human-readable notification for Wowza output
 $response = 
@@ -36,4 +40,3 @@ fwrite($fp, "\r\n\r\n");
 */
 
 fclose($fp);
-?>

--- a/stream-un-publish-signature-validation.php
+++ b/stream-un-publish-signature-validation.php
@@ -1,0 +1,46 @@
+<?php
+// WMSPanel publish/un-publish streams events notification signature validation sample
+
+/* Replace the token with your token from "Global push API" settings page before testing! */
+$token = "INSERT_YOUR_TOKEN_HERE";
+
+if($_SERVER['REQUEST_METHOD'] !== "POST")
+{
+    die("notifications are only sent as a POST request.");
+}
+
+/* Read POST data */
+$data = file_get_contents("php://input");
+
+/* Open a log file for debugging purposes. */
+$fp = fopen('log.txt', 'a+');
+
+/* Decode the JSON POST data */
+$notification = json_decode($data, true);
+
+/* Make sure that all required parameters are present for validation to work. */
+if(!array_key_exists("ID", $notification) || !array_key_exists("Puzzle", $notification) || !array_key_exists("Signature", $notification))
+{
+    die("Not all required parameters for validation are present.");
+}
+
+$id = $notification['ID'];
+$puzzle = $notification['Puzzle'];
+$signature = $notification['Signature'];
+
+/* Calculate the signature based on our "Token" from the "Global push API" settings page */
+$calculatedSignature = base64_encode(md5($id . $puzzle . $token, true));
+
+if($signature === $calculatedSignature)
+{
+    fwrite($fp, "The signature was validated successfully!");
+}
+else
+{
+    fwrite($fp, "The signature could not be validated.\r\n");
+    fwrite($fp, "Expected signature: " . $signature . "\r\n");
+    fwrite($fp, "Calculated signature: " . $calculatedSignature . "\r\n");
+}
+
+fwrite($fp, "\r\n\r\n");
+fclose($fp);


### PR DESCRIPTION
- HTTP_RAW_POST_DATA was deprecated in PHP 5.6 and removed in PHP 7.0. 
- Added simple request method check as the notifications only use POST requests
- Added an example to validate the signature for (un)publish notifications